### PR TITLE
Bugfix: Querystring is not passed to the RewritePath methode

### DIFF
--- a/EPiServer.CdnSupport/CdnModule.cs
+++ b/EPiServer.CdnSupport/CdnModule.cs
@@ -49,7 +49,7 @@ namespace EPiServer.CdnSupport
             if (_mediaPaths.Any(p => newPath.StartsWith(p)))
             {
                 c.Items[CdnRequest] = c.Request.Path.Substring(1, 6);
-                c.RewritePath("/" + newPath, String.Empty, String.Empty, true);
+                c.RewritePath("/" + newPath, String.Empty, c.Request.QueryString.ToString(), true);
             }
         }
 


### PR DESCRIPTION
Querystring is not passed to the RewritePath methode, when translating back to original path(and query). To be able to use CDN for images resized through ImageResizer, this change need to be done.